### PR TITLE
Add support for output formats other than ES6 and Ractive parse options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
+.idea/
 node_modules
 dist

--- a/README.md
+++ b/README.md
@@ -26,7 +26,14 @@ rollup({
 
       // You can restrict which files are compiled
       // using `include` and `exclude`
-      include: 'src/components/**.html'
+      include: 'src/components/**.html',
+      
+      // Output format. When doing server-side rendering, you might need to set this
+      // to "cjs" if you import other JS files in your components.
+      format: 'es6',
+      
+      // Options passed to Ractive.parse()
+      parseOptions: {}
     })
   ]
 }).then(...)

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "rollup-plugin-buble": "^0.14.0"
   },
   "dependencies": {
-    "rcu": "^0.9.0",
+    "rcu": "^0.10.2",
     "rcu-builders": "^0.6.0",
     "rollup-pluginutils": "^1.3.1"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,15 @@
 import { extname } from 'path';
 import Ractive from 'ractive';
 import rcu from 'rcu';
-import { es6 } from 'rcu-builders';
+import * as builders from 'rcu-builders';
 import { createFilter } from 'rollup-pluginutils';
 
 rcu.init( Ractive );
 
 export default function dsv ( options = {} ) {
 	const filter = createFilter( options.include, options.exclude );
-
 	const extensions = options.extensions || [ '.html' ];
+	const format = options.format || 'es6';
 
 	return {
 		name: 'ractive',
@@ -20,7 +20,7 @@ export default function dsv ( options = {} ) {
 			if ( !~extensions.indexOf( extname( id ) ) ) return null;
 
 			const definition = rcu.parse( code, options.parseOptions );
-			const module = es6( definition, {
+			const module = builders[ format ]( definition, {
 				preserveExtensions: true,
 				sourceMap: true
 			});

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ export default function dsv ( options = {} ) {
 
 			if ( !~extensions.indexOf( extname( id ) ) ) return null;
 
-			const definition = rcu.parse( code );
+			const definition = rcu.parse( code, options.parseOptions );
 			const module = es6( definition, {
 				preserveExtensions: true,
 				sourceMap: true


### PR DESCRIPTION
When doing SSR with Ractive, you can't use `import` in Ractive files, and using `require()` with [rollup-plugin-commonjs](https://github.com/rollup/rollup-plugin-commonjs) doesn't work either, because this plugin only outputs ES6.

This PR adds support for other output formats supported by `rcu-builders` and for specifying custom Ractive parse options.